### PR TITLE
feat: update tomcat role to include resource links

### DIFF
--- a/polaris/deploy/README.md
+++ b/polaris/deploy/README.md
@@ -1,3 +1,7 @@
 # Ansible Collection - polaris.deploy
 
 Documentation for the collection.
+
+# tomcat_jndi_resources and tomcat_jndi_resource_link
+
+if "using_alt_app_dir" is provided the "tomcat_server.xml.j2" file will add a context attribute to the server.xml file. Further more we are allowing one or more local resource link to be added which allows the GlobalNamingResources to be available to the deployed application.

--- a/polaris/deploy/roles/tomcat/defaults/main.yml
+++ b/polaris/deploy/roles/tomcat/defaults/main.yml
@@ -59,6 +59,7 @@ tomcat_deployOnStartup:           yes
 tomcat_shutdown_port:             -1
 tomcat_keystore_pass:             "{{ ssc_keystore_pass | default(default_ssc_keystore_pass) }}"
 tomcat_jndi_resources:            []
+tomcat_jndi_resource_link:            []
 
 # logging.properties
 tomcat_configure_logging_properties:  yes

--- a/polaris/deploy/roles/tomcat/templates/tomcat-server.xml.j2
+++ b/polaris/deploy/roles/tomcat/templates/tomcat-server.xml.j2
@@ -99,7 +99,7 @@
 
 {% if using_alt_app_dir %}
                 <Context path="/{{ context | regex_replace('#', '/') }}" docBase="{{ tomcat_webapp_dir }}/{{ alt_app_dir_name }}">
-                 {% for link in tomcat_jndi_resource_inks %}
+                 {% for link in tomcat_jndi_resource_links %}
                     <ResourceLink global="{{ link.global }}" name="{{ link.name }}" type="{{ link.type }}" />
                  {% endfor %}
                 </Context>

--- a/polaris/deploy/roles/tomcat/templates/tomcat-server.xml.j2
+++ b/polaris/deploy/roles/tomcat/templates/tomcat-server.xml.j2
@@ -98,7 +98,11 @@
                 workDir="{{ tomcat_work_dir }}" >
 
 {% if using_alt_app_dir %}
-                <Context path="/{{ context | regex_replace('#', '/') }}" docBase="{{ tomcat_webapp_dir }}/{{ alt_app_dir_name }}"></Context>
+                <Context path="/{{ context | regex_replace('#', '/') }}" docBase="{{ tomcat_webapp_dir }}/{{ alt_app_dir_name }}">
+                 {% for link in tomcat_jndi_resource_inks %}
+                    <ResourceLink global="{{ link.global }}" name="{{ link.name }}" type="{{ link.type }}" />
+                 {% endfor %}
+                </Context>
 {% endif %}
 
                 <Valve className="org.apache.catalina.valves.AccessLogValve"


### PR DESCRIPTION
Update to tomcat-server.xml.j2 to allow one or more resource links to be created for a context for the deployed applications.